### PR TITLE
Add `tbro#send_keys` and `TbroKeys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ seem to do a lot more than what I wanted to do. All tbro does is send your
 command to the pane specified by `g:tbro_pane`. That's it.
 
 ## Usage
+
 In vim you can call `Tbro command` to send "command" to the pane specified by
 `g:tbro_pane`. Use `ctrl+a q` (or whatever your tmux prefix is) to display your
 panes id's. The default pane is pane 1. If you want to target a different pane,
 just set `let g:tbro_pane = 2` or call `:TbroPane` (be sure to use tab complete
 with `:TbroPane`!).
+
+Tbro provides a way to send raw keys to a pane using the `TbroKeys`. For
+example, you can send control+c by calling `TbroKeys C-c`.
 
 You can also run the last command with `TbroRedo`.
 
@@ -19,6 +23,8 @@ used with [vim-rspec](vim-rspec) and to have custom maps calling `Tbro` with
 predefined commands or to be used with other plugins. To use Tbro with
 vim-rspec, you can call `let g:rspec_command="Tbro rspec {spec}"` and
 vim-rspec will use Tbro to call run spec.
+
+For more specific usage, run `:help tbro` in vim.
 
 ## Mapping
 

--- a/doc/tbro.txt
+++ b/doc/tbro.txt
@@ -6,9 +6,10 @@ Repo: http://github.com/BlakeWilliams/vim-tbro
 
 COMMANDS                                                              *tbro*
 
-:Tbro [args]     Sends command to pane specified by g:tbro_pane
-:TbroRedo        Re-sends last command sent to pane specified by g:tbro_pane
-:TbroPane        Changes the target pane and completes pane in current window
+:Tbro [args]       Sends command to pane specified by g:tbro_pane
+:TbroRaw [args]    Sends raw keys to pane specified by g:tbro_pane
+:TbroRedo          Re-sends last command sent to pane specified by g:tbro_pane
+:TbroPane          Changes the target pane and completes pane in current window
 
 FUNCTIONS                                                   *tbro-functions*
 
@@ -19,16 +20,19 @@ commands, but prefer :Tbro, :TbroRedo, and :TbroPane when available.
 * tbro#send(command, pane_string)
   Sends command to tmux pane specified by optional pane_string
 
+* tbro#send_raw(command, pane_string)
+  Sends raw keys to tmux pane specified by optional pane_string
+
 * tbro#redo()
   Re-sends the last function called with tbro#send
 
 * tbro#set_pane(pane_string)
-  Sets the g:tbro_pane variable. Mostly for autocomplete 
+  Sets the g:tbro_pane variable. Mostly for autocomplete
 
 * tbro#run_line()
-  Runs the line the cursor is currently on in the target pane.
+  Runs the line the cursor is currently on in the target pane
 
 * tbro#run_selection()
-  Runs the current selection in the target pane.
+  Runs the current selection in the target pane
 
 vim:tw=78:et:ft=help:norl:

--- a/plugin/tbro.vim
+++ b/plugin/tbro.vim
@@ -32,6 +32,20 @@ function! tbro#send(command, ...) abort
   endif
 endfunction
 
+function! tbro#send_keys(command, ...)
+  if a:0 == 1
+    let pane_id = a:1
+  else
+    let pane_id = g:tbro_pane
+  end
+
+  call system("tmux send-keys -t '".pane_id."' ".a:command)
+
+  if v:shell_error
+    echohl WarningMsg | echo output[0:-2] | echohl None
+  endif
+endfunction
+
 function! tbro#redo()
   call tbro#send(g:tbro_last_command)
 endfunction
@@ -42,7 +56,7 @@ endfunction
 
 function! tbro#pane_complete(...)
   call system('tmux display-panes')
-  return system('tmux list-panes -F "#S:#I.#P"')
+  return system('tmux list-panes -F "#P"')
 endfunction
 
 function! tbro#run_line()
@@ -54,6 +68,7 @@ function! tbro#run_selection() range
 endfunction
 
 command! -nargs=1 -complete=shellcmd Tbro call tbro#send(<q-args>)
+command! -nargs=1 -complete=shellcmd TbroRaw call tbro#send_keys(<q-args>)
 command! -nargs=1 -complete=custom,tbro#pane_complete TbroPane
       \ call tbro#set_pane('<args>')
 command! TbroRedo call tbro#redo()


### PR DESCRIPTION
Adding the `tbro#send_keys` function and `TbroKeys` lets Tbro send raw
key commands directly to panes. This allows you to send arguments like
`C-c` which would send control+c to the pre-specified tmux pane.
